### PR TITLE
Bump python version to 3.8

### DIFF
--- a/conda_environment.yaml
+++ b/conda_environment.yaml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - pip
-  - python=3.6.5
+  - python=3.8
   - numpy
   - scipy
   - pandas
@@ -51,3 +51,4 @@ dependencies:
   - jupyter_nbextensions_configurator
   - pytest
   - jupytext
+  - mypy


### PR DESCRIPTION
DAPS2 will be python>3.7 so when bumping we might as well bump to latest stable version

Also: added mypy to deps